### PR TITLE
check if envdir is a directory

### DIFF
--- a/envdir/__main__.py
+++ b/envdir/__main__.py
@@ -50,6 +50,9 @@ class Runner(object):
         if not os.path.exists(real_path):
             # use 111 error code to adher to envdir's standard
             self.parser.error("envdir %r does not exist" % path, no=111)
+        if not os.path.isdir(real_path):
+            # use 111 error code to adher to envdir's standard
+            self.parser.error("envdir %r not a directory" % path, no=111)
         return real_path
 
     def read(self, path=None):

--- a/tests.t
+++ b/tests.t
@@ -61,6 +61,15 @@ The envdir does not exist
   envdir: error: envdir 'non-existant' does not exist
   [111]
 
+The envdir must be a directory
+
+  $ touch not-a-directory
+  $ envdir not-a-directory ls
+  Usage: envdir [--help] [--version] dir child
+  
+  envdir: error: envdir 'not-a-directory' not a directory
+  [111]
+
 Error code proxy
 
   $ mkdir errorcode


### PR DESCRIPTION
If a file path was specified as envdir directory, py-envdir tried to read env files from `'filepath/*'`.
Since glob does not care if these paths exist or not, instead of raising error,
glob just returns `[]` and no environment variables are overwritten.

On djb's original implementation, envdir raises 111 error for such case.
# djb envdir's behavior::

```
  $ /usr/bin/envdir /etc/hostname ls
  envdir: fatal: unable to switch to directory /etc/hostname: not a directory
  $ echo $?
  111
```

Changed py-envdir to bahave just like djs envdir.
