### PR TITLE
Keep file descriptors with Popen (for `is_windows`)

### DIFF
--- a/envdir/runner.py
+++ b/envdir/runner.py
@@ -110,7 +110,7 @@ class Runner(object):
             self.process = subprocess.Popen(args,
                                             universal_newlines=True,
                                             bufsize=0,
-                                            close_fds=not is_windows,
+                                            close_fds=False,
                                             **params)
             self.process.wait()
         except OSError as err:


### PR DESCRIPTION
Closing file descriptors makes envdir impossible to use with chaussette,
and I cannot see why that should get done - only that it has been
changed to `not is_windows` for some reason.

Fixes #16
