### PR TITLE
Change `isenvvar()` to only check for `=` in var names

### DIFF
--- a/envdir/env.py
+++ b/envdir/env.py
@@ -9,9 +9,7 @@ except ImportError:
 
 def isenvvar(name):
     root, name = os.path.split(name)
-    return (name == name.upper() and
-            not name.startswith('_') and
-            not '=' in name)
+    return '=' not in name
 
 
 class Env(UserDict):

--- a/envdir/test_envdir.py
+++ b/envdir/test_envdir.py
@@ -80,6 +80,28 @@ line
     assert os.environ['MULTI_LINE'] == 'multi\nline'
 
 
+def test_lowercase_var_names(run, tmpenvdir):
+    "Lowercase env var name"
+    tmpenvdir.join('lowercase-variable').write("test")
+    with py.test.raises(Response) as response:
+        run('envdir', str(tmpenvdir), 'ls')
+    assert 'lowercase-variable' in os.environ
+    assert os.environ['lowercase-variable'] == 'test'
+    assert response.value.status == 0
+    assert response.value.message == ''
+
+
+def test_var_names_prefixed_by_underscore(run, tmpenvdir):
+    "Underscore prefixed env var name"
+    tmpenvdir.join('_UNDERSCORE_VAR').write("test")
+    with py.test.raises(Response) as response:
+        run('envdir', str(tmpenvdir), 'ls')
+    assert '_UNDERSCORE_VAR' in os.environ
+    assert os.environ['_UNDERSCORE_VAR'] == 'test'
+    assert response.value.status == 0
+    assert response.value.message == ''
+
+
 def test_translate_nulls(run, tmpenvdir):
     "NULLs are translated into newline"
     tmpenvdir.join('NULL_CHARS').write("""null\x00character""")


### PR DESCRIPTION
Daemontools' envdir only checks for `=`, thus this python envdir version should have the same behavior.

Using both daemontools and python envdirs:

```
$ cat foo
bar
$ cat _foo
bar
$ cat foo=bar
foobar


$ cat a.py
import os
print('foo="{}"'.format(os.getenv("foo")))
print('_foo="{}"'.format(os.getenv("_foo")))
print('foo=bar="{}"'.format(os.getenv("foo=bar")))


# python envdir
$ python -m envdir . python a.py
foo="None"
_foo="None"
foo=bar="None"


# daemontools envdir
$ envdir . python a.py
foo="bar"
_foo="bar"
foo=bar="None"
```
