### PR TITLE
WIP: Use `os.execvpe` with `run`, fix `shell`

### DIFF
--- a/envdir/runner.py
+++ b/envdir/runner.py
@@ -1,19 +1,10 @@
 import optparse
 import os
-import signal
 import subprocess
 import sys
 
 from .env import Env
 from .version import __version__
-
-# must have shell = True on Windows
-is_windows = sys.platform == 'win32'
-
-if is_windows:
-    params = {'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP}
-else:
-    params = {'preexec_fn': os.setsid}
 
 
 class Response(Exception):
@@ -30,7 +21,6 @@ class Runner(object):
         self.parser = optparse.OptionParser(version=__version__)
         self.parser.disable_interspersed_args()
         self.parser.prog = 'envdir'
-        signal.signal(signal.SIGTERM, self.terminate)
 
     def path(self, path):
         real_path = os.path.realpath(os.path.expanduser(path))
@@ -62,7 +52,7 @@ class Runner(object):
         options, args = self.parser.parse_args(list(args))
 
         if len(args) == 0:
-            raise Response("%s\nError: incorrect number of arguments" %
+            raise Response("%s\nError: incorrect number of arguments\n" %
                            (self.parser.get_usage()), 2)
 
         sys.stdout.write("Launching envshell for %s. "
@@ -74,14 +64,11 @@ class Runner(object):
         shell = os.environ['SHELL']
 
         try:
-            subprocess.check_call([shell],
-                                  universal_newlines=True,
-                                  bufsize=0,
-                                  close_fds=not is_windows,
-                                  **params)
+            subprocess.call([shell])
         except OSError as err:
             if err.errno == 2:
-                raise Response("Unable to find shell %s" % shell, err.errno)
+                raise Response("Unable to find shell %s" % shell,
+                               status=err.errno)
             else:
                 raise Response("An error occurred: %s" % err,
                                status=err.errno)
@@ -107,35 +94,9 @@ class Runner(object):
             args = args[1:]
 
         try:
-            self.process = subprocess.Popen(args,
-                                            universal_newlines=True,
-                                            bufsize=0,
-                                            close_fds=False,
-                                            **params)
-            self.process.wait()
+            os.execvpe(args[0], args, os.environ)
         except OSError as err:
-            if err.errno == 2:
-                raise Response("Unable to find command %s" %
-                               args[0], err.errno)
-            else:
-                raise Response(status=err.errno)
-        except KeyboardInterrupt:
-            self.terminate()
-        raise Response(status=self.process.returncode)
+            raise Response("Unable to run command %s: %s" %
+                           (args[0], err.errstr), status=err.errno)
 
-    def terminate(self, *args, **kwargs):
-        # first send mellow signal
-        self.quit(signal.SIGTERM)
-        if self.process.poll() is None:
-            # still running, kill it
-            self.quit(signal.SIGKILL)
-
-    def quit(self, signal):
-        if self.process.poll() is None:
-            proc_pgid = os.getpgid(self.process.pid)
-            if os.getpgrp() == proc_pgid:
-                # Just kill the proc, don't kill ourselves too
-                os.kill(self.process.pid, signal)
-            else:
-                # Kill the whole process group
-                os.killpg(proc_pgid, signal)
+        raise Response()


### PR DESCRIPTION
Use `exec` to replace the envdir process with the child process (fixes #20).

This commit also fixes `(env)shell` to behave properly when `Ctrl-C` is
pressed in the subprocess (apparently caused by using os.setsid).

This is work in progress, since tests are failing.

I have asked for support in py.test at https://bitbucket.org/hpk42/pytest/issue/511/support-for-calls-to-osexec .
