### PR TITLE
fix running tox on python2.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 envlist = py26,py27,pypy,py32,py33,py34,flake827,flake834
+minversion=1.8
 
 [testenv]
 deps =
     pytest
     coverage
+    py26: argparse
 commands =
     coverage run --source=envdir/ -m pytest []
     coverage report -m --omit=envdir/test_envdir.py


### PR DESCRIPTION
because argparse must be installed seperately on python2.6
and we can use a new factor specific settings from tox 1.8
