### PR TITLE
new feature: optional prompt for envshell

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -53,4 +53,19 @@ For example:
 
 To leave the subshell, simply use the ``exit`` command or press ``Ctrl+D``.
 
+After running ``envshell`` you will have two extra environment variables
+available:
+
+* ``ENVSHELL_PATH`` contains a full path to a directory that was used
+  as an argument for ``envshell``.
+* ``ENVSHELL_NAME`` is just a basename of that directory.
+
+Those variables can help you set a prompt for your newly created shell session.
+
+For example with Bash you can have this line at the end of a
+``~/.bashrc`` file to have a convenient prefix in the prompt::
+
+    if [ -n "$ENVSHELL_NAME" ]; then PS1=[envshell:$ENVSHELL_NAME]$PS1; fi
+
+
 .. _envdir: http://cr.yp.to/daemontools/envdir.html

--- a/envdir/runner.py
+++ b/envdir/runner.py
@@ -62,7 +62,7 @@ class Runner(object):
                          "Type 'exit' or 'Ctrl+D' to return.\n" %
                          self.path(args[0]))
         sys.stdout.flush()
-        self.open(args[0], 2)
+        env = self.open(args[0], 2)
 
         if 'SHELL' in os.environ:
             shell = os.environ['SHELL']
@@ -70,6 +70,11 @@ class Runner(object):
             shell = os.environ['COMSPEC']
         else:
             raise Response('Unable to detect current environment shell')
+
+        if 'PS1' in os.environ:
+            os.environ['ENVDIR_PS1'] = \
+                '[envdir:{0}]{1}'.format(os.path.basename(env.path),
+                                         os.environ['PS1'])
 
         try:
             subprocess.call([shell])

--- a/envdir/runner.py
+++ b/envdir/runner.py
@@ -71,10 +71,8 @@ class Runner(object):
         else:
             raise Response('Unable to detect current environment shell')
 
-        if 'PS1' in os.environ:
-            os.environ['ENVDIR_PS1'] = \
-                '[envdir:{0}]{1}'.format(os.path.basename(env.path),
-                                         os.environ['PS1'])
+        os.environ['ENVSHELL_PATH'] = env.path
+        os.environ['ENVSHELL_NAME'] = os.path.basename(env.path)
 
         try:
             subprocess.call([shell])

--- a/envdir/test_envdir.py
+++ b/envdir/test_envdir.py
@@ -250,6 +250,17 @@ def test_shell_doesnt_exist(shell, tmpenvdir):
     assert "Unable to find shell" in response.value.message
 
 
+def test_shell_extra_vars(shell, tmpenvdir):
+    "Test presence of extra env vars after running shell"
+    path = str(tmpenvdir)
+
+    with py.test.raises(Response):
+        shell('envshell', path)
+
+    assert os.environ['ENVSHELL_PATH'] == path
+    assert os.environ['ENVSHELL_NAME'] == os.path.basename(path)
+
+
 def test_read(tmpenvdir):
     tmpenvdir.join('READ').write('test')
     applied = envdir.read(str(tmpenvdir))


### PR DESCRIPTION
this sets a new env variable called `ENVDIR_PS1`
before running a new shell so for example in bash
it can be used to set a new shell prompt
(similar to virtualenv)

all you'd need to do is add a line similar to this
at the bottom of your .bashrc

```
PS1=${ENVDIR_PS1:-${PS1}}
```

so after running `envshell ./test/` you would get `[envdir:test]`
at the beginning of your prompt.
