### PR TITLE
Set encoding to utf-8 on reading parts.

### DIFF
--- a/envdir/test_envdir.py
+++ b/envdir/test_envdir.py
@@ -277,19 +277,13 @@ if 'READ_MAGIC' in os.environ:
         envdir.run('envdir', str(tmp))
     out, err = capfd.readouterr()
 
-    if py.std.sys.version_info[:2] == (2, 6):
-        assert response.value == 2
-    else:
-        assert response.value.code == 2
+    assert response.value.code == 2
     assert "incorrect number of arguments" in err
 
     with py.test.raises(SystemExit) as response:
         envdir.run()
     out, err = capfd.readouterr()
-    if py.std.sys.version_info[:2] == (2, 6):
-        assert response.value == 2
-    else:
-        assert response.value.code == 2
+    assert response.value.code == 2
 
 
 def test_read_existing_var(tmpenvdir):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class VersionFinder(ast.NodeVisitor):
 
 
 def read(*parts):
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+    return codecs.open(os.path.join(here, *parts), 'r', encoding='utf8').read()
 
 
 def find_version(*parts):

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,15 @@ commands =
     coverage run --source=envdir/ -m pytest []
     coverage report -m --omit=envdir/test_envdir.py
 
+# Use coverage<4 with Python 3.2.
+[testenv:py32]
+deps =
+    pytest
+    coverage<4
+commands =
+    coverage run --source=envdir/ -m pytest []
+    coverage report -m --omit=envdir/test_envdir.py
+
 [testenv:flake827]
 basepython = python2.7
 deps = flake8


### PR DESCRIPTION
Installation of envdir on python3 fails in an environment with no locale/$LANG, as codecs.open() falls back to ASCII. 