### PR TITLE
Only strip newlines, but not spaces from var files

### DIFF
--- a/envdir/env.py
+++ b/envdir/env.py
@@ -63,7 +63,7 @@ class Env(UserDict):
         if not os.path.exists(path):
             return default
         with self._open(name) as var:
-            return var.read().strip().replace('\x00', '\n')
+            return var.read().strip('\n').replace('\x00', '\n')
 
     def _set(self, name, value):
         if name in os.environ:

--- a/envdir/test_envdir.py
+++ b/envdir/test_envdir.py
@@ -117,6 +117,16 @@ line
     assert os.environ['MULTI_LINE'] == 'multi\nline'
 
 
+def test_space_at_end(run, tmpenvdir, monkeypatch):
+    """Space at end of envdir file."""
+    monkeypatch.setattr(os, 'execvpe', functools.partial(mocked_execvpe,
+                                                         monkeypatch))
+    tmpenvdir.join('WITH_SPACE').write("with space ")
+    with py.test.raises(Response):
+        run('envdir', str(tmpenvdir), 'ls')
+    assert os.environ['WITH_SPACE'] == 'with space '
+
+
 def test_lowercase_var_names(run, tmpenvdir, monkeypatch):
     "Lowercase env var name"
     monkeypatch.setattr(os, 'execvpe', functools.partial(mocked_execvpe,


### PR DESCRIPTION
Without this an additional space at the end would get removed.