### PR TITLE
import Response exeception class into package namespace

### DIFF
--- a/envdir/__init__.py
+++ b/envdir/__init__.py
@@ -1,5 +1,6 @@
 from .__main__ import runner, go
 from .env import Env  # noqa
+from .runner import Response
 from .version import __version__  # noqa
 
 open = runner.open


### PR DESCRIPTION
Partial fix for issue #52. Imports Response exception class into the main package namespace.