### PR TITLE
Fix RuntimeWarning when running python -m envdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ htmlcov
 .coverage
 docs/_build
 dist/
+**/*.pyc

--- a/envdir/__init__.py
+++ b/envdir/__init__.py
@@ -1,4 +1,4 @@
-from .__main__ import runner, go
+from .runner import runner, go
 from .env import Env  # noqa
 from .version import __version__  # noqa
 

--- a/envdir/__main__.py
+++ b/envdir/__main__.py
@@ -1,22 +1,4 @@
-import sys
-
-from .runner import Runner, Response
-
-runner = Runner()
-
-
-def go(caller, *args):
-    if not args:
-        args = sys.argv
-    try:
-        caller(args[0], *args[1:])
-    except Response as response:
-        if response.message:
-            sys.stderr.write(response.message)
-        sys.exit(response.status or 0)
-    else:
-        sys.exit(0)
-
+from .runner import go, runner
 
 if __name__ == '__main__':
     go(runner.run)  # pragma: no cover

--- a/envdir/runner.py
+++ b/envdir/runner.py
@@ -108,3 +108,19 @@ class Runner(object):
                            (args[0], err), status=err.errno)
 
         raise Response()
+
+
+def go(caller, *args):
+    if not args:
+        args = sys.argv
+    try:
+        caller(args[0], *args[1:])
+    except Response as response:
+        if response.message:
+            sys.stderr.write(response.message)
+        sys.exit(response.status or 0)
+    else:
+        sys.exit(0)
+
+
+runner = Runner()


### PR DESCRIPTION
Running 'python -m envdir' currently gives a RuntimeWarning:
```
RuntimeWarning: 'envdir.__main__' found in sys.modules after import of package 'envdir', but prior to execution of 'envdir.__main__'; this may result in unpredictable behaviour
```
